### PR TITLE
Fix for error in Update Location during Initial Attach

### DIFF
--- a/mme/S6a/SQLqueries.h
+++ b/mme/S6a/SQLqueries.h
@@ -46,7 +46,7 @@ const char exists_auth_vec[]="SELECT EXISTS (SELECT '1' FROM auth_vec WHERE (mcc
 const char get_auth_vec[]="SELECT rand, autn, xres, kasme FROM auth_vec WHERE (mcc, mnc, msin, ksi) = (%u, %u, x'%.10llu', %u)";
 
 const char update_location[] = "UPDATE subscriber_profile "
-        "SET mmec=x'%.2x', mmegi=x'%s', network_access_mode = '%u'"
+        "SET mmec=CONV('%.2x',16,10), mmegi=CONV('%s',16,10), network_access_mode = '%u'"
         "WHERE (mcc, mnc, msin) = (%u, %u, x'%.10llu')";
 
 const char get_subscriber_profile[] = "SELECT "

--- a/mme/S6a/scripts/hss_lte_db.sql
+++ b/mme/S6a/scripts/hss_lte_db.sql
@@ -134,8 +134,3 @@ CREATE TABLE `subscriber_profile` (
 # DB access rights
 grant delete,insert,select,update on hss_lte_db.* to hss@localhost identified by 'hss';
 
-# Commands to remove STRICT_TRANS_TABLES mode, if it is enabled
-# STRICT_TRANS_TABLES mode makes the UpdateLocation procedure to fail during initial attach
-# the mode is enabled by default in MariaDB from version 10.2.4 on.
-set sql_mode = 'ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';
-set GLOBAL sql_mode = 'ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION';


### PR DESCRIPTION
ERROR DESCRIPTION: mmec and mmegi in table subscriber_profile are tinyint and smallint respectively. Nevertheless, the query which performs the update location assumes such columns to have type binary. If STRICT_TRANS_TABLES in MariaDB is set to OFF, then just a warning is generated (and a wrong value is stored in the database). If STRICT_TRANS_TABLES in MariaDB is set to ON instead, an error is generated, aborting the update location operation. Note that STRICT_TRANS_TABLES is ON by default in MariaDB from version 10.2.4 on.

FIX DESCRIPTION: instead of converting the HEX string into binary, the fix converts the HEX string into a decimal value, which is the one expected from the database. With such change, there is no more the need of setting STRICT_TRANS_TABLES to OFF.